### PR TITLE
Update to use cljsjs/react-bootstrap lib

### DIFF
--- a/devcards_src/bootstrap_cljs_devcards.cljs
+++ b/devcards_src/bootstrap_cljs_devcards.cljs
@@ -7,7 +7,7 @@
             [om-tools.core :refer-macros [defcomponent]]
             [weasel.repl :as repl])
   (:require-macros [devcards.core :refer [defcard]]
-                   [bootstrap-cljs :as bs]))
+                   [bootstrap-cljs.core :as bs]))
 
 (enable-console-print!)
 

--- a/project.clj
+++ b/project.clj
@@ -6,9 +6,10 @@
   :jar-exclusions [#"\.cljx\.swp|\.swo|\.DS_Store"]
   :source-paths ["target/generated/src/clj" "src"]
   :resource-paths ["target/generated/src/cljs" "resources"]
-  :dependencies [[org.clojure/clojure "1.7.0"]
-                 [org.clojure/clojurescript "1.7.122"]
-                 [prismatic/om-tools "0.3.12"]]
+  :dependencies [[org.clojure/clojure "1.7.0" :scope "provided"]
+                 [org.clojure/clojurescript "1.7.122" :scope "provided"]
+                 [cljsjs/react-bootstrap "0.27.3-0"]
+                 [prismatic/om-tools "0.4.0"]]
   :scm {:name "git"
         :url "https://github.com/luxbock/bootstrap-cljs"}
   :deploy-repositories [["clojars" {:creds :gpg}]]

--- a/src/bootstrap_cljs/core.cljc
+++ b/src/bootstrap_cljs/core.cljc
@@ -1,5 +1,7 @@
-(ns bootstrap-cljs
-  (:require [clojure.string :as str]
+(ns bootstrap-cljs.core
+  (:refer-clojure :exclude [use mask])
+  (:require #?(:cljs cljsjs.react-bootstrap)
+            [clojure.string :as str]
             [om-tools.dom :as omt]))
 
 (defn kebab-case
@@ -53,13 +55,13 @@
     Well])
 
 #?(:clj
-    (defn ^:private gen-bootstrap-inline-fn [tag]
-      `(defmacro ~(symbol (kebab-case (str tag)))
-         [opts# & children#]
-         (let [ctor# '(.createFactory js/React (~(symbol (str ".-" (name tag))) js/ReactBootstrap))]
-           (if (om-tools.dom/literal? opts#)
-             (let [[opts# children#] (om-tools.dom/element-args opts# children#)]
-               (cond
+   (defn ^:private gen-bootstrap-inline-fn [tag]
+     `(defmacro ~(symbol (kebab-case (str tag)))
+        [opts# & children#]
+        (let [ctor# '(.createFactory js/React (~(symbol (str ".-" (name tag))) js/ReactBootstrap))]
+          (if (om-tools.dom/literal? opts#)
+            (let [[opts# children#] (om-tools.dom/element-args opts# children#)]
+              (cond
                 (every? (complement om-tools.dom/possible-coll?) children#)
                 `(~ctor# ~opts# ~@children#)
 
@@ -68,11 +70,11 @@
 
                 :else
                 `(apply ~ctor# ~opts# (flatten (vector ~@children#)))))
-             `(om-tools.dom/element ~ctor# ~opts# (vector ~@children#)))))))
+            `(om-tools.dom/element ~ctor# ~opts# (vector ~@children#)))))))
 
 #?(:clj
-    (defmacro ^:private gen-bootstrap-inline-fns []
-      `(do ~@(clojure.core/map gen-bootstrap-inline-fn bootstrap-tags))))
+   (defmacro ^:private gen-bootstrap-inline-fns []
+     `(do ~@(clojure.core/map gen-bootstrap-inline-fn bootstrap-tags))))
 
 #?(:clj
-    (gen-bootstrap-inline-fns))
+   (gen-bootstrap-inline-fns))

--- a/test/bootstrap_cljs/core_test.clj
+++ b/test/bootstrap_cljs/core_test.clj
@@ -1,6 +1,6 @@
 (ns bootstrap-cljs.core-test
   (:require [clojure.test :refer :all]
-            [bootstrap-cljs :refer :all]))
+            [bootstrap-cljs.core :refer :all]))
 
 (deftest a-test
   (testing "FIXME, I fail."


### PR DESCRIPTION
So it automatically includes the the javascript dependencies and
externs. Closes #7

Rename bootstrap-cljs ns to bootstrap-cljs.core to remove compilation
warning and conform to best practices.
http://dev.clojure.org/jira/browse/CLJS-1028

Update om-tools version