### PR TITLE
Update library to react-bootstrap 0.29.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,5 +11,6 @@ pom.xml.asc
 /.repl
 /out
 /resources/public/js/out
+figwheel_server.log
 
 

--- a/devcards_src/bootstrap_cljs/devcards.cljs
+++ b/devcards_src/bootstrap_cljs/devcards.cljs
@@ -358,7 +358,7 @@
                (dom/option {:value "select"} "select (multiple)")
                (dom/option {:value "other"} "..."))
      (bs/input {:type "textarea" :default-value "textarea"})
-     (bs/form-controls-static "static")))
+     (bs/form-control-static "static")))
    (dom/hr)
    (mkdn "## Addons")
    (mkdn "Use `:addon-before` and `:addon-after`")

--- a/devcards_src/bootstrap_cljs/devcards.cljs
+++ b/devcards_src/bootstrap_cljs/devcards.cljs
@@ -405,6 +405,30 @@
             (bs/button "Before"))
           (bs/form-control {:type "text"}))))))
 
+(defcard validation-states
+  (react-card
+    (mkdn "## Validation states")
+    (mkdn "Set `:validation-state` to one of 'success', 'warning' or
+    'error'. Add `form-control-feedback` for a feedback icon.")
+
+    (bs/form-group {:control-id "formValidationSuccess1" :validation-state "success"}
+      (bs/control-label "Input with success")
+      (bs/form-control {:type "text"})
+      (bs/help-block "Help text with valiation state"))
+
+    (bs/form-group {:control-id "formValidationSuccess1" :validation-state "warning"}
+      (bs/control-label "Input with warning")
+      (bs/form-control {:type "text"}))
+
+    (bs/form-group {:control-id "formValidationSuccess1" :validation-state "error"}
+      (bs/control-label "Input with error")
+      (bs/form-control {:type "text"}))
+
+    (bs/form-group {:control-id "formValidationSuccess1" :validation-state "success"}
+      (bs/control-label "Input with success and feeback icon")
+      (bs/form-control {:type "text"})
+      (bs/form-control-feedback nil))))
+
 (defcomponent modal [data owner]
   (init-state [_]
               {:visible? false})

--- a/devcards_src/bootstrap_cljs/devcards.cljs
+++ b/devcards_src/bootstrap_cljs/devcards.cljs
@@ -249,7 +249,7 @@
    (dom/hr)
 
    (mkdn "### Tabs")
-   (bs/tabs {:default-active-key 2}
+   (bs/tabs {:default-active-key 2 :id "tabs-example"}
      (map (fn [num]
             (bs/tab {:event-key num :title (str "Tab " num)}
               (dom/div {:style {:padding "10px"}} (str "Content " num)))) (range 1 4)))

--- a/devcards_src/bootstrap_cljs/devcards.cljs
+++ b/devcards_src/bootstrap_cljs/devcards.cljs
@@ -314,58 +314,96 @@
    (dom/div
     (map #(dom/h4 (bs/label {:bs-style %} (str/capitalize %))) styles))))
 
-(defcard ccc (react-card (mkdn "## Input")))
-
-(defcomponent input-component
-  [data owner]
-  (init-state [_] {:value "" :length 0})
-  (render-state [_ {:keys [value length]}]
-                (bs/input
-                 {:type               "text"
-                  :value              value
-                  :placeholder        "Enter some text"
-                  :label              "Working example with validation"
-                  :help               "Validates based on string length."
-                  :bs-style           (condp < length 10 "success" 5 "warning" "error")
-                  :has-feedback       true
-                  :ref                "input"
-                  :group-class-name   "group-class"
-                  :wrapper-class-name "wrapper-class"
-                  :label-class-name   "label-class"
-                  :on-change          #(om/update-state! owner
-                                                         (fn [_]
-                                                           (let [new-value (.. owner -refs -input getValue)]
-                                                             {:value new-value :length (count new-value)})))})))
-
-(defcard om-input-component (dc/om-root input-component))
+(defcard forms-header (react-card (mkdn "# Forms")))
 
 (defcard ex-17
   (react-card
-   (dom/br)
-   (mkdn "Supports `select`, `textarea`, `static` as well as standard HTML
-    input types.")
-   (dom/hr)
-   (dom/div
+    (mkdn "## Supported Controls")
+    (dom/hr)
+    (dom/div
+      (dom/form
+        (bs/form-group {:control-id "formControlsText"}
+          (bs/control-label "Text")
+          (bs/form-control {:type "text" :placeholder "enter text"}))
+
+        (bs/form-group {:control-id "formControlsEmail"}
+          (bs/control-label "Email Address")
+          (bs/form-control {:type "email" :placeholder "enter email"}))
+
+        (bs/form-group {:control-id "formControlsPassword"}
+          (bs/control-label "Password")
+          (bs/form-control {:type "password"}))
+
+        (bs/form-group {:control-id "formControlsFile"}
+          (bs/control-label "File")
+          (bs/form-control {:type "file"})
+          (bs/help-block "Example block-level help text here."))
+
+        (bs/checkbox {:checked true :read-only true} "Checkbox")
+
+        (bs/radio {:checked true :read-only true} "Radio")
+
+        (bs/form-group
+          (bs/checkbox {:inline true} 1)
+          (bs/checkbox {:inline true} 2)
+          (bs/checkbox {:inline true} 3))
+
+        (bs/form-group
+          (bs/radio {:inline true} 1)
+          (bs/radio {:inline true} 2)
+          (bs/radio {:inline true} 3))
+
+        (bs/form-group {:control-id "formControlsSelect"}
+          (bs/control-label "Select")
+          (bs/form-control {:component-class "select" :placeholder "select"}
+            (dom/option {:value "select"} "select")
+            (dom/option {:value "other"} "...")))
+
+        (bs/form-group {:control-id "formControlsSelectMultiple"}
+          (bs/control-label "Multiple Select")
+          (bs/form-control {:component-class "select" :multiple true}
+            (dom/option {:value "select"} "select (multiple)")
+            (dom/option {:value "other"} "...")))
+
+        (bs/form-group {:control-id "formControlsTextarea"}
+          (bs/control-label "Textarea")
+          (bs/form-control {:component-class "textarea" :placeholder "textarea"}))
+
+        (bs/form-group
+          (bs/control-label "Static Text")
+          (bs/form-control-static "email@example.com"))))))
+
+(defcard ex-input-groups
+  (react-card
+    (mkdn "## Input groups")
     (dom/form
-     (bs/input {:type "text" :default-value "text"})
-     (bs/input {:type "password" :default-value "secret"})
-     (bs/input {:type "checkbox" :checked true :read-only true :label "checkbox"})
-     (bs/input {:type "radio" :checked true :read-only true :label "radio"})
-     (bs/input {:type "select" :default-value "select"}
-               (dom/option {:value "select"} "select")
-               (dom/option {:value "other"} "..."))
-     (bs/input {:type "select" :multiple true}
-               (dom/option {:value "select"} "select (multiple)")
-               (dom/option {:value "other"} "..."))
-     (bs/input {:type "textarea" :default-value "textarea"})
-     (bs/form-control-static "static")))
-   (dom/hr)
-   (mkdn "## Addons")
-   (mkdn "Use `:addon-before` and `:addon-after`")
-   (dom/form
-    (bs/input {:type "text" :addon-before "@"})
-    (bs/input {:type "text" :addon-after "♡"})
-    (bs/input {:type "text" :addon-before "$"}))))
+      (bs/form-group
+        (bs/input-group
+          (bs/input-group-addon "@")
+          (bs/form-control {:type "text"})))
+
+      (bs/form-group
+        (bs/input-group
+          (bs/form-control {:type "text"})
+          (bs/input-group-addon ".00")))
+
+      (bs/form-group
+        (bs/input-group
+          (bs/input-group-addon "@")
+          (bs/form-control {:type "text"})
+          (bs/input-group-addon ".00")))
+
+      (bs/form-group
+        (bs/input-group
+          (bs/form-control {:type "text"})
+          (bs/input-group-addon
+            (bs/glyphicon {:glyph "music"}))))
+
+      (bs/form-group
+        (bs/input-group
+          (bs/input-group-button
+            (bs/button "Before"))
+          (bs/form-control {:type "text"}))))))
 
 (defcomponent modal [data owner]
   (init-state [_]

--- a/devcards_src/bootstrap_cljs/devcards.cljs
+++ b/devcards_src/bootstrap_cljs/devcards.cljs
@@ -16,7 +16,8 @@
 
 ;; Run `lein figwheel` and open the browser to http://localhost:3449/index.html
 
-(defn mkdn [& mkd-strs] (apply dc/markdown->react mkd-strs))
+(defn mkdn [& mkd-strs] (dom/div
+                          (apply dc/markdown->react mkd-strs)))
 (defn react-card [& content] (dom/div content))
 
 (def positions ["left" "top" "bottom" "right"])

--- a/devcards_src/bootstrap_cljs/devcards.cljs
+++ b/devcards_src/bootstrap_cljs/devcards.cljs
@@ -246,12 +246,12 @@
                          (bs/menu-item {:key "4" :divider true})
                          (bs/menu-item {:key "5"} "Separated link"))))
    (dom/hr)
+
    (mkdn "### Tabs")
    (bs/tabs {:default-active-key 2}
-            (map #(bs/tab {:key % :tab (str "Tab " %)}
-                   (dom/div {:style {:padding "10px"}}
-                            (str "Content " %)))
-                 (range 1 7)))
+     (map (fn [num]
+            (bs/tab {:event-key num :title (str "Tab " num)}
+              (dom/div {:style {:padding "10px"}} (str "Content " num)))) (range 1 4)))
    (dom/hr)
    (mkdn "### Pagers")
    (bs/pager

--- a/project.clj
+++ b/project.clj
@@ -8,14 +8,14 @@
   :resource-paths ["target/generated/src/cljs" "resources"]
   :dependencies [[org.clojure/clojure "1.7.0" :scope "provided"]
                  [org.clojure/clojurescript "1.7.228" :scope "provided"]
-                 [cljsjs/react-bootstrap "0.28.1-1"]
+                 [cljsjs/react-bootstrap "0.29.2-0"]
                  [prismatic/om-tools "0.4.0"]]
   :scm {:name "git"
         :url "https://github.com/luxbock/bootstrap-cljs"}
   :deploy-repositories [["clojars" {:creds :gpg}]]
   :profiles
-  {:dev {:dependencies [[devcards "0.2.1-5"]
-                        [org.omcljs/om "0.9.0"]
+  {:dev {:dependencies [[devcards "0.2.1-6"]
+                        [org.omcljs/om "1.0.0-alpha34"]
                         [com.cemerick/piggieback "0.2.2-SNAPSHOT"]
                         [org.slf4j/slf4j-nop "1.7.13" :scope "test"]
                         [org.clojure/tools.nrepl "0.2.10"]]

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject bootstrap-cljs "0.28.1-1-SNAPSHOT"
+(defproject bootstrap-cljs "0.29.2.0"
   :description "ClojureScript wrapper around React Bootstrap"
   :url "https://github.com/luxbock/bootstrap-cljs"
   :license {:name "Eclipse Public License"

--- a/src/bootstrap_cljs/core.cljc
+++ b/src/bootstrap_cljs/core.cljc
@@ -31,6 +31,7 @@
     Dropdown.Toggle
     FormGroup
     FormControl
+    FormControl.Feedback
     Glyphicon
     Grid
     HelpBlock

--- a/src/bootstrap_cljs/core.cljc
+++ b/src/bootstrap_cljs/core.cljc
@@ -21,16 +21,24 @@
     ButtonToolbar
     Carousel
     CarouselItem
+    Checkbox
     Col
     CollapsibleNav
+    ControlLabel
     Dropdown
     DropdownButton
     Dropdown.Menu
     Dropdown.Toggle
+    FormGroup
+    FormControl
     Glyphicon
     Grid
+    HelpBlock
     Image
     Input
+    InputGroup
+    InputGroup.Addon
+    InputGroup.Button
     Jumbotron
     Label
     ListGroup
@@ -66,6 +74,7 @@
     PanelGroup
     Popover
     ProgressBar
+    Radio
     ResponsiveEmbed
     Row
     SafeAnchor

--- a/src/bootstrap_cljs/core.cljc
+++ b/src/bootstrap_cljs/core.cljc
@@ -79,7 +79,7 @@
     Well
     Collapse
     Fade
-    FormControls.Static])
+    FormControl.Static])
 
 #?(:clj
    (defn ^:private gen-bootstrap-inline-fn [tag]


### PR DESCRIPTION
Hi,

I noticed that this library was a little out of date with react-bootstrap, so I bumped the dependencies, added some new components, and cleaned up the devcard examples.

All of the deprecation warnings were fixed in devcards with one exception, which I'm not sure the best way to fix:
<img width="836" alt="screen shot 2016-05-07 at 2 20 35 pm" src="https://cloud.githubusercontent.com/assets/465987/15093769/25c024d6-145f-11e6-8e5b-8c14efef6db2.png">

there is explanation for why some changes were necessary in the commit descriptions